### PR TITLE
reselect caching expensive state

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ WIP - vector drawing + verlet physical constraints
 
 ## todo
 
-- [ ] Make it work
-- [ ] Make it right
+- [x] Make it work
+- [x] Make it right
 - [ ] Make it fast
 - [ ] Make it pretty

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "choo": "^4.1.0",
     "expr-eval": "^1.0.0",
+    "reselect": "^2.5.4",
     "sheetify": "^6.0.1",
     "verlet-constraint": "^1.1.0",
     "verlet-point": "^1.2.1",

--- a/src/app-selectors.js
+++ b/src/app-selectors.js
@@ -1,0 +1,26 @@
+const Parser = require('expr-eval').Parser
+const {createSelector} = require('reselect')
+
+const getMeasurements = function (state) {
+  return state.pattern.measurements
+}
+
+// Expensive should be stuff cached til state.pattern.measurements changes
+const getSolvedMeasurements = createSelector(
+  [ getMeasurements ],
+  (measurements) => {
+    const {base, derived} = measurements
+    let solved = {}
+    for (let i = 0, len = base.length; i < len; i++) {
+      const {key, value} = base[i]
+      solved[key] = value
+    }
+    for (let i = 0, len = derived.length; i < len; i++) {
+      const {key, value} = derived[i]
+      solved[key] = Parser.evaluate(value, solved)
+    }
+    return solved
+  }
+)
+
+module.exports = {getSolvedMeasurements}

--- a/src/app.js
+++ b/src/app.js
@@ -82,7 +82,7 @@ function mainView (state, prev, send) {
         <h2>base part shapes</h2>
         ${olParts(reflectedParts, solvedParts, selectedPart, send)}
         <h2>constraints</h2>
-        ${(selectedPart != null) && olConstraints(parts[selectedPart].constraints)}
+        ${(selectedPart != null) && olConstraints(reflectedParts[selectedPart].constraints)}
         todo:
         <ul>
           <li>add parts</li>
@@ -92,7 +92,7 @@ function mainView (state, prev, send) {
       <section>
         <h2>solved shape</h2>
         <input type="range" min="0" max="360" value="${solverSteps}" oninput=${onSetSteps} style="width: 500px;" />
-        ${(selectedPart != null) && svgConstrained(parts[selectedPart], solvedMeasurements, solverSteps, 500, 500, send)}
+        ${(selectedPart != null) && svgConstrained(reflectedParts[selectedPart], solvedMeasurements, solverSteps, 500, 500, send)}
         todo: select points in selected part, add/edit distance/angle constraints
       </section>
       <section>

--- a/src/app.js
+++ b/src/app.js
@@ -3,6 +3,7 @@ const choo = require('choo')
 const xtend = require('xtend')
 const css = require('sheetify')
 
+const {getSolvedMeasurements} = require('./app-selectors')
 const olParts = require('./ol-parts')
 const olMeasurements = require('./ol-measurements')
 const olDerived = require('./ol-derived')
@@ -44,6 +45,7 @@ const model = {
         }
       }
       pattern.measurements.base = base
+      pattern.measurements = xtend(pattern.measurements, {})
       pattern = xtend(pattern, {})
       return {pattern}
     },
@@ -56,6 +58,7 @@ const model = {
 function mainView (state, prev, send) {
   const {pattern, selectedPart, solverSteps} = state
   const {id, parts, measurements} = pattern
+  const solvedMeasurements = getSolvedMeasurements(state)
 
   function onSetSteps (event) {
     const value = parseInt(event.target.value, 10)
@@ -75,7 +78,7 @@ function mainView (state, prev, send) {
       </section>
       <section>
         <h2>base part shapes</h2>
-        ${olParts(parts, measurements, selectedPart, send)}
+        ${olParts(parts, solvedMeasurements, selectedPart, send)}
         <h2>constraints</h2>
         ${(selectedPart != null) && olConstraints(parts[selectedPart].constraints)}
         todo:
@@ -87,7 +90,7 @@ function mainView (state, prev, send) {
       <section>
         <h2>solved shape</h2>
         <input type="range" min="0" max="360" value="${solverSteps}" oninput=${onSetSteps} style="width: 500px;" />
-        ${(selectedPart != null) && svgConstrained(parts[selectedPart], measurements, solverSteps, 500, 500, send)}
+        ${(selectedPart != null) && svgConstrained(parts[selectedPart], solvedMeasurements, solverSteps, 500, 500, send)}
         todo: select points in selected part, add/edit distance/angle constraints
       </section>
       <section>

--- a/src/app.js
+++ b/src/app.js
@@ -3,7 +3,7 @@ const choo = require('choo')
 const xtend = require('xtend')
 const css = require('sheetify')
 
-const {getSolvedMeasurements} = require('./app-selectors')
+const {getSolvedMeasurements, getPartsPoints, getSolvedParts} = require('./app-selectors')
 const olParts = require('./ol-parts')
 const olMeasurements = require('./ol-measurements')
 const olDerived = require('./ol-derived')
@@ -59,6 +59,8 @@ function mainView (state, prev, send) {
   const {pattern, selectedPart, solverSteps} = state
   const {id, parts, measurements} = pattern
   const solvedMeasurements = getSolvedMeasurements(state)
+  const reflectedParts = getPartsPoints(state)
+  const solvedParts = getSolvedParts(state)
 
   function onSetSteps (event) {
     const value = parseInt(event.target.value, 10)
@@ -78,7 +80,7 @@ function mainView (state, prev, send) {
       </section>
       <section>
         <h2>base part shapes</h2>
-        ${olParts(parts, solvedMeasurements, selectedPart, send)}
+        ${olParts(reflectedParts, solvedParts, selectedPart, send)}
         <h2>constraints</h2>
         ${(selectedPart != null) && olConstraints(parts[selectedPart].constraints)}
         todo:

--- a/src/app.js
+++ b/src/app.js
@@ -73,7 +73,7 @@ function mainView (state, prev, send) {
         ${olMeasurements(measurements.base, send)}
         todo: load from bodylabs
         <h2>derived values</h2>
-        ${olDerived(measurements.derived)}
+        ${olDerived(measurements.derived, solvedMeasurements)}
         todo: add & edit
       </section>
       <section>

--- a/src/ol-derived.js
+++ b/src/ol-derived.js
@@ -1,17 +1,19 @@
 const html = require('choo/html')
 
-const liDerived = function (measurement, index) {
-  return html`
-  <li>
-    <label>
-      ${measurement.key}
-      <input type="text" value="${measurement.value}" disabled></input>
-    </label>
-  </li>
-  `
-}
+const olDerived = function (measurements, solvedMeasurements) {
 
-const olDerived = function (measurements) {
+  const liDerived = function (measurement, index) {
+    return html`
+    <li>
+      <label>
+        ${measurement.key}
+        <input type="text" value="${measurement.value}" disabled></input>
+        ${solvedMeasurements[measurement.key]}
+      </label>
+    </li>
+    `
+  }
+
   return html`
   <ol>
     ${measurements.map(liDerived)}

--- a/src/ol-parts.js
+++ b/src/ol-parts.js
@@ -1,6 +1,5 @@
 const html = require('choo/html')
 const xtend = require('xtend')
-const svgConstrained = require('./svg-constrained')
 const svgPart = require('./svg-part')
 // const component = require('nanocomponent')
 
@@ -8,8 +7,10 @@ const WIDTH = 72
 const HEIGHT = 72
 
 const liPart = /*component({
-  render:*/ function (part, index, selected, measurements, send) {
+  render:*/ function (part, solvedPart, index, selected, send) {
     const {points, constraints, symmetry, id} = part
+    const {systemPoints, systemDistances, systemAngles} = solvedPart
+
     function onClick () {
       send('selectPart', index)
     }
@@ -21,7 +22,7 @@ const liPart = /*component({
       onclick=${onClick}
     >
       ${svgPart(points, symmetry, null, WIDTH, HEIGHT)}
-      ${svgConstrained(part, measurements, 360, WIDTH, HEIGHT)}
+      ${svgPart(systemPoints, symmetry, constraints, WIDTH, HEIGHT, systemDistances, systemAngles)}
       ${id}
     </li>
     `
@@ -35,27 +36,13 @@ const liPart = /*component({
 })*/
 
 const olParts = /*component({
-  render:*/ function (parts, measurements, selectedIndex, send) {
+  render:*/ function (parts, solvedParts, selectedIndex, send) {
     return html`
     <ol>
       ${parts.map(
         function (part, index) {
-          const {id, from, reflect} = part
-          if (from) {
-            for (let i = 0, len = parts.length; i < len; i++) {
-              const fromPart = parts[i]
-              if (fromPart.id === from) {
-                const xReflect = reflect.indexOf('x') > -1 ? -1 : 1
-                const yReflect = reflect.indexOf('y') > -1 ? -1 : 1
-                const points = fromPart.points.map(function (point) {
-                  return {x: point.x * xReflect, y: point.y * yReflect}
-                })
-                part = xtend(parts[i], {id, points})
-              }
-            }
-          }
           const selected = (selectedIndex === index)
-          return liPart(part, index, selected, measurements, send)
+          return liPart(part, solvedParts[index], index, selected, send)
         }
       )}
     </ol>

--- a/src/verlet-solver.js
+++ b/src/verlet-solver.js
@@ -4,7 +4,6 @@
 const System = require('verlet-system')
 const Point = require('verlet-point')
 const Constraint = require('verlet-constraint')
-const Parser = require('expr-eval').Parser
 const {AngleConstraint, rotate} = require('./verlet-constraint-angle-2d')
 const {pointsWithSymmetry, distanceBetween} = require('./geometry.js')
 
@@ -43,23 +42,7 @@ function verticesRotate (vertices, a1, b1, a2, b2) {
 }
 
 function getDistance (constraint, measurements) {
-  const {base, derived} = measurements
-  let baseObj = {}
-  for (let i = 0, len = base.length; i < len; i++) {
-    const {key, value} = base[i]
-    if (constraint.distance === key) {
-      return value
-    }
-    baseObj[key] = value
-  }
-  // TODO cache these?
-  for (let i = 0, len = derived.length; i < len; i++) {
-    const {key, value} = derived[i]
-    baseObj[key] = Parser.evaluate(value, baseObj)
-    if (constraint.distance === key) {
-      return baseObj[key]
-    }
-  }
+  if (measurements[constraint.distance]) return measurements[constraint.distance]
   throw new Error('measurement not found')
 }
 


### PR DESCRIPTION
This is what I was looking for... a simple API to cache some derived state based on simple `===` memoization.

So far:
- [x] measurements are parsed and solved only when they change, moving that complexity up
- [x] parts that reflect other part's points
- [x] verlet solving of parts